### PR TITLE
Allow use with all ember versions >= 1.4, including 2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,6 @@
     "tests"
   ],
   "dependencies": {
-    "ember": ">=1.4 <2"
+    "ember": ">=1.4"
   }
 }


### PR DESCRIPTION
I think it's safe to let the shims be used with all future version of ember, since the shim should be in lock-step until it's no longer needed at all AFAIK.