### PR TITLE
Don't break if jQuery is missing

### DIFF
--- a/app-shims.js
+++ b/app-shims.js
@@ -282,5 +282,5 @@
 
   processEmberShims();
   processEmberDataShims();
-  generateModule('jquery', { 'default': window.jQuery });
+  generateModule('jquery', { 'default': self.jQuery });
 })();

--- a/app-shims.js
+++ b/app-shims.js
@@ -282,5 +282,5 @@
 
   processEmberShims();
   processEmberDataShims();
-  generateModule('jquery', { 'default': jQuery });
+  generateModule('jquery', { 'default': window.jQuery });
 })();


### PR DESCRIPTION
Fastboot doesn't have jQuery and this fixes it.

I'm not sure if this should be fixed here or in Fastboot, but Fastboot works with v0.0.3 of shims.