### PR TITLE
Bump the ember dependency version?

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,6 @@
     "tests"
   ],
   "dependencies": {
-    "ember": ">=1.4"
+    "ember": "2.0.0"
   }
 }


### PR DESCRIPTION
Using the latest ember-cli, docs suggest that one can bump ember and ember-data to 2.0.0 at will--but currently this will result in "Unable to find a suitable version for ember" bc of this dependency on 1.X. Not sure if this the correct resolution right now, but it appears that way to me.