### PR TITLE
Bump version to 1.0.0.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "app-shims.js",
     "test-shims.js"
   ],
-  "version": "0.0.5",
+  "version": "1.0.0",
   "homepage": "https://github.com/ember-cli/ember-cli-shims",
   "authors": [
     "Stefan Penner <stefan.penner@gmail.com>",


### PR DESCRIPTION
Per https://github.com/ember-cli/ember-cli/pull/4809, this will allow
loose versioning and remove the need of pointing to GitHub.