### PR TITLE
Add getProperties to ember-metal/get

### DIFF
--- a/app-shims.js
+++ b/app-shims.js
@@ -104,7 +104,8 @@
         'send':           Ember.sendEvent
       },
       'ember-metal/get': {
-        'default': Ember.get
+        'default': Ember.get,
+        'getProperties': Ember.getProperties
       },
       'ember-metal/mixin': {
         'default': Ember.Mixin


### PR DESCRIPTION
I am not sure if this was intentionally left out, but I noticed it was missing when I was moving an app away from using the Ember global.