### PR TITLE
Remove ember-data shims.

### DIFF
--- a/app-shims.js
+++ b/app-shims.js
@@ -214,28 +214,7 @@
     }
   }
 
-  function processEmberDataShims() {
-    var shims = {
-      'ember-data':                          '',
-      'ember-data/model':                    'Model',
-      'ember-data/serializers/rest':         'RESTSerializer',
-      'ember-data/serializers/active-model': 'ActiveModelSerializer',
-      'ember-data/serializers/json':         'JSONSerializer',
-      'ember-data/serializers/json-api':     'JSONAPISerializer',
-      'ember-data/adapters/json-api':        'JSONAPIAdapter',
-      'ember-data/adapters/rest':            'RESTAdapter',
-      'ember-data/adapter':                  'Adapter',
-      'ember-data/adapters/active-model':    'ActiveModelAdapter',
-      'ember-data/store':                    'Store',
-      'ember-data/transform':                'Transform',
-      'ember-data/attr':                     'attr',
-      'ember-data/relationships':            ['hasMany', 'belongsTo']
-    };
-
-    for (var moduleName in shims) {
-      generateLazyModule('DS', moduleName, shims[moduleName]);
-    }
-
+  function processTestShims() {
     if (Ember.Test) {
       var testShims = {
         'ember-test': {
@@ -282,7 +261,7 @@
   }
 
   processEmberShims();
-  processEmberDataShims();
+  processTestShims();
   generateModule('jquery', { 'default': self.jQuery });
   generateModule('rsvp', { 'default': Ember.RSVP });
 })();


### PR DESCRIPTION
They have been moved upstream, and are included automatically as of 2.3.0.

This change will warrant a "breaking" change, and result in 0.1.0.