### PR TITLE
remove DS global jshint

### DIFF
--- a/app-shims.js
+++ b/app-shims.js
@@ -1,5 +1,5 @@
 (function() {
-/* globals define, Ember, DS, jQuery */
+/* globals define, Ember, jQuery */
 
   function processEmberShims() {
     var shims = {


### PR DESCRIPTION
Since the ember-data shims are removed, there's no longer a need to add a globals jshint for "DS".