### PR TITLE
Add Babel 6 compatibility

### DIFF
--- a/app-shims.js
+++ b/app-shims.js
@@ -246,6 +246,10 @@
     define(name, [], function() {
       'use strict';
 
+      Object.defineProperty(values, '__esModule', {
+        value: true
+      });
+
       return values;
     });
   }


### PR DESCRIPTION
This PR adds a `__esModule` property to the shims to make it compatible with the AMD module transform in Babel 6.

/cc @stefanpenner @rwjblue