### PR TITLE
Bower: Fix "invalid-meta" warning

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,7 @@
 {
   "name": "ember-cli-shims",
   "main": [
-    "app-shims.js",
-    "test-shims.js"
+    "app-shims.js"
   ],
   "version": "0.1.3",
   "homepage": "https://github.com/ember-cli/ember-cli-shims",


### PR DESCRIPTION
```
invalid-meta - The "main" field has to contain only 1 file per filetype; found multiple .js files: ["app-shims.js","test-shims.js"]
```

see also https://github.com/emberjs/ember.js/pull/14167