### PR TITLE
Add missing isEqual export in ember-utils

### DIFF
--- a/app-shims.js
+++ b/app-shims.js
@@ -192,6 +192,7 @@
       'ember-utils': {
         'isBlank':    Ember.isBlank,
         'isEmpty':    Ember.isEmpty,
+        'isEqual':    Ember.isEqual,
         'isNone':     Ember.isNone,
         'isPresent':  Ember.isPresent,
         'tryInvoke':  Ember.tryInvoke,


### PR DESCRIPTION
It's part of the public API: http://emberjs.com/api/#method_isEqual