### PR TITLE
Added `isHTMLSafe` to the `ember-string` shims.

### DIFF
--- a/vendor/ember-cli-shims/app-shims.js
+++ b/vendor/ember-cli-shims/app-shims.js
@@ -185,6 +185,7 @@
         'decamelize':   Ember.String.decamelize,
         'fmt':          Ember.String.fmt,
         'htmlSafe':     Ember.String.htmlSafe,
+        'isHTMLSafe':   Ember.String.isHTMLSafe,
         'loc':          Ember.String.loc,
         'underscore':   Ember.String.underscore,
         'w':            Ember.String.w


### PR DESCRIPTION
So `Ember.String.isHTMLSafe` was added in Ember 2.8. I was tempted to include the [ember-string-ishtmlsafe-polyfill](https://github.com/workmanw/ember-string-ishtmlsafe-polyfill) as a dependency, however we've been following the pattern of [ember-assign-polyfill](https://github.com/shipshapecode/ember-assign-polyfill) and [ember-getowner-polyfill](https://github.com/rwjblue/ember-getowner-polyfill) and neither of them are deps here. 

I think it's logical to say that a consumer of `ember-cli-shims` using < Ember-2.8 has to also include the `ember-string-ishtmlsafe-polyfill` for themselves. 