### PR TITLE
Update to Babel 6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.2.1",
+    "ember-cli-babel": "^6.0.0-beta.7",
     "ember-cli-version-checker": "^1.2.0",
     "silent-error": "^1.0.1"
   },
@@ -28,7 +28,7 @@
     "ember-cli": "^2.11.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.0-beta.2",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.1.0",
     "ember-cli-sri": "^2.1.0",


### PR DESCRIPTION
As part of the work for ember-cli@2.13, all "built in" addons are being updated to use ember-cli-babel@6.

We do not currently have `addon/**/*.js` files, but we are likely to land them in https://github.com/ember-cli/ember-cli-shims/pull/92 so I just updated the various versions and left the dependency.