### PR TITLE
Remove allowed failure for ember-beta channel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:


### PR DESCRIPTION
The upstream issue that forced this to be an allowed failure has
been fixed.