### PR TITLE
Enable yarn cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
 sudo: false
 
 cache:
+  yarn: true
   directories:
     - $HOME/.npm
 


### PR DESCRIPTION
Since we have `yarn.lock`, we could take advantage of [yarn cache](https://docs.travis-ci.com/user/caching#yarn-cache). To actually use Yarn on our CI machines, we're likely going to have to install it [ourselves](https://yarnpkg.com/en/docs/install-ci#travis-tab).