### PR TITLE
README: Clarify when you can drop from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Ember CLI Shims
 
 **Note:  this project is deprecated.  If you are using these shims in your project you should migrate to the new modules api outlined in [RFC 176](https://github.com/emberjs/rfcs/blob/master/text/0176-javascript-module-api.md) as soon as you can.  More information on this topic in [the Ember 2.16 release blog post](https://emberjs.com/blog/2017/10/11/ember-2-16-released.html#toc_ember-js-modules-api).**
 
+Note that you won't be able to drop this dependency from your app's `package.json` file until all your addons have upgraded to ember-cli-babel >= 6.6.0.
+
 About
 -----
 


### PR DESCRIPTION
I couldn't figure out why dropping it was biting me until someone pointed this detail out on Slack.